### PR TITLE
bug fix selecting vCenter update version

### DIFF
--- a/vmware_vcenter_upgrade.py
+++ b/vmware_vcenter_upgrade.py
@@ -173,7 +173,8 @@ class VMwareVCenterUpgrade(PyVmomi):
     def get_upgrade_from_version(self):
         for upgrade_version in self.upgrade_data:
             if upgrade_version['version'] is self.version:
-                return self.version
+                
+        return self.version
 
     def get_upgrade_from_latest(self):
         latest = '0.0.0'

--- a/vmware_vcenter_upgrade.py
+++ b/vmware_vcenter_upgrade.py
@@ -173,8 +173,7 @@ class VMwareVCenterUpgrade(PyVmomi):
     def get_upgrade_from_version(self):
         for upgrade_version in self.upgrade_data:
             if upgrade_version['version'] is self.version:
-                
-        return self.version
+                return self.version
 
     def get_upgrade_from_latest(self):
         latest = '0.0.0'

--- a/vmware_vcenter_upgrade.py
+++ b/vmware_vcenter_upgrade.py
@@ -175,8 +175,6 @@ class VMwareVCenterUpgrade(PyVmomi):
             if upgrade_version['version'] is self.version:
                 return self.version
 
-        return '0.0.0'
-
     def get_upgrade_from_latest(self):
         latest = '0.0.0'
 


### PR DESCRIPTION
In order for this module to work when setting a custom vCenter update version (i.e. 7.0.3.00800) a small line of code had to be changed that returns the version instead of 0.0.0. Not changing this line of code will result in the module failing.

Fix for issue described in issue: #2 